### PR TITLE
Feature/add command line call

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ This repository has the following requirements (see also [`requirements.txt`](re
  -  `netCDF4`
  -  `numpy`
  -  `shapely`
+ -  `typer`
  -  `xarray`
 
 Instead of installing `netCDF4`, the `xarray`-package can also be installed with the `I/O`-option enabled:

--- a/README.md
+++ b/README.md
@@ -114,6 +114,14 @@ from src.processing import map_ecotopes
 
 results = map_ecotopes('<hydrodynamic_output_data_file>.nc', wd='<working/directory>')
 ```
+There is also the option to use `EMMA` from the command line directly:
+```commandline
+emma run hydrodynamic_output_data_file.nc --wd working/directory
+```
+**Note** that the latter usage provides limited customisation. Call for the included features:
+```commandline
+emma run --help
+```
 By default, `EMMA` expects the relevant hydrodynamic variables to be named as given by [`dfm1.json`](config/dfm1.json). 
 In case these key-words differ in the provided `netCDF`-file (dependent on the hydrodynamic modelling software used), 
 provide a custom (partially overwriting) `*.json`-file with the same key-words as in [`dfm1.json`](config/dfm1.json); 
@@ -123,3 +131,4 @@ In the [`examples`](examples)-folder, a collection of examples are provided on h
 additional features. A [dummy output-file](examples/ex_map_data) is added that can be used to test the examples. For the
 examples, there is also an additional [`README`](examples/README.md) in the [`examples`](examples)-folder to provide
 some background to the examples, where needed.
+**Note** that these examples all make use of the `Python`-based execution of `EMMA`.

--- a/__init__.py
+++ b/__init__.py
@@ -6,6 +6,6 @@ Authors: Soesja Brunink & Gijs G. Hendrickx
 """
 __all__ = ['config', 'examples', 'src']
 
-__version__ = '1.0'
+__version__ = '1.1'
 __author__ = 'Soesja Brunink & Gijs G. Hendrickx'
 __description__ = 'Ecotope map maker based on abiotic characteristics'

--- a/__init__.py
+++ b/__init__.py
@@ -1,11 +1,11 @@
 """
-EMMA stands for 'Ecotope Map Maker based on Abiotic characteristics' and is a Python-based translation from hydrodynamic
-model output data to ecotopes.
+EMMA stands for 'Ecotope-Map Maker based on Abiotics' and is a Python-based translation from hydrodynamic model output
+data to ecotopes.
 
-Authors: Soesja Brunink & Gijs G. Hendrickx
+Authors: Gijs G. Hendrickx & Soesja Brunink
 """
 __all__ = ['config', 'examples', 'src']
 
 __version__ = '1.1'
-__author__ = 'Soesja Brunink & Gijs G. Hendrickx'
-__description__ = 'Ecotope map maker based on abiotic characteristics'
+__author__ = 'Gijs G. Hendrickx & Soesja Brunink'
+__description__ = 'Ecotope-Map Maker based on Abiotics'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 netCDF4
 numpy
 shapely
+typer
 xarray

--- a/setup.py
+++ b/setup.py
@@ -34,5 +34,10 @@ setup(
         'shapely',
         'xarray',
     ],
+    entry_points={
+        'console_scripts': [
+            'emma = src.console:app_emma',
+        ]
+    },
     python_requires='>=3.9',
 )

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         'netCDF4',
         'numpy',
         'shapely',
+        'typer',
         'xarray',
     ],
     entry_points={

--- a/src/console.py
+++ b/src/console.py
@@ -14,6 +14,14 @@ APP = typer.Typer()
 
 
 def __log_levels(log: str) -> str:
+    """Callback function for allowed log-levels.
+
+    :param log: log-level
+    :type log: str
+
+    :return: log-level
+    :rtype: str
+    """
     # capitalise all strings
     log = log.upper()
     levels = 'DEBUG', 'INFO', 'WARNING', 'CRITICAL'
@@ -37,6 +45,25 @@ def run(
         n_cores: te.Annotated[int, typer.Option(min=1, help='number of cores for parallel computations')] = 1,
         wd: te.Annotated[str, typer.Option(help='working directory')] = None,
 ) -> None:
+    """Run EMMA with limited modifications from the command-line. For the full spectrum of customisation, EMMA should be
+    executed using Python, and calling the `src.processing.map_ecotopes`-function.
+
+    :param map_files: file name(s) of hydrodynamic model output data (*.nc)
+    :param export: export data, defaults to True
+    :param f_eco_config: file name of ecotopes configuration file, defaults to 'emma.json'
+    :param f_map_config: file name of mapping configuration file, defaults to 'dfm1.json'
+    :param log: log-level {'DEBUG', 'INFO', 'WARNING', 'CRITICAL'}, defaults to 'WARNING'
+    :param n_cores: number of cores available for parallel computations, defaults to 1
+    :param wd: working directory, defaults to None
+
+    :type map_files: list[str]
+    :type export: bool, optional
+    :type f_eco_config: str, optional
+    :type f_map_config: str, optional
+    :type log: str, optional
+    :type n_cores: int, optional
+    :type wd: str, optional
+    """
     # noinspection PyArgumentList
     processing.map_ecotopes(
         *map_files,
@@ -56,8 +83,21 @@ def run(
 def compare(
         map_files: te.Annotated[typing.List[str], typer.Argument(help='hydrodynamic output map-file(s)')],
         f_ecotopes: te.Annotated[str, typer.Argument(help='file with ecotope polygon data')],
+        wd: te.Annotated[str, typer.Option(help='working directory')] = None,
 ) -> None:
-    msg = f'The compare function is not yet implemented (map_files={map_files}, f_ecotopes={f_ecotopes})'
+    """Compare predictions of ecotopes based on EMMA with existing polygon-data of ecotopes.
+
+    :param map_files: file name(s) of hydrodynamic model output data (*.nc)
+    :param f_ecotopes: file name of ecotope-polygon data
+    :param wd: working directory, defaults to None
+
+    :type map_files: list[str]
+    :type f_ecotopes: str
+    :type wd: str, optional
+
+    :raise NotImplementedError: function not yet implemented as console-accessible call
+    """
+    msg = f'The compare function is not yet implemented (map_files={map_files}, f_ecotopes={f_ecotopes}, wd={wd})'
     raise NotImplementedError(msg)
 
 

--- a/src/console.py
+++ b/src/console.py
@@ -47,14 +47,19 @@ def __print_statements() -> None:
     )
 
 
+# noinspection PyUnresolvedReferences
 @app_emma.command(name='run', help='execution of EMMA with customisation of the basic optional arguments')
 def run(
         map_files: te.Annotated[typing.List[str], typer.Argument(help='hydrodynamic output map-file(s)')],
         export: te.Annotated[bool, typer.Option(help='export model data to [wd]')] = True,
         f_eco_config: te.Annotated[str, typer.Option(help='ecotope configuration file')] = 'emma.json',
         f_map_config: te.Annotated[str, typer.Option(help='map configuration file')] = 'dfm1.json',
-        log: te.Annotated[str, typer.Option(callback=__log_levels, help='level of log statements')] = 'WARNING',
-        n_cores: te.Annotated[int, typer.Option(min=1, help='number of cores for parallel computations')] = 1,
+        log: te.Annotated[str, typer.Option(
+            '--log', '-l', autocompletion=__log_levels, callback=__log_levels, help='level of log statements'
+        )] = 'WARNING',
+        n_cores: te.Annotated[int, typer.Option(
+            '--cores', '-n', min=1, help='number of cores for parallel computation'
+        )] = 1,
         wd: te.Annotated[str, typer.Option(help='working directory')] = None,
 ) -> None:
     """Run EMMA with limited modifications from the command-line. For the full spectrum of customisation, EMMA should be

--- a/src/console.py
+++ b/src/console.py
@@ -4,6 +4,7 @@ Run EMMA from the command-line.
 Author: Gijs G. Hendrickx
 """
 import os
+import sys
 import typing
 
 import typer
@@ -11,6 +12,7 @@ import typing_extensions as te
 
 from src import processing
 
+# EMMA-application
 app_emma = typer.Typer()
 
 
@@ -106,20 +108,21 @@ def compare(
     :type map_files: list[str]
     :type f_ecotopes: str
     :type wd: str, optional
-
-    :raise NotImplementedError: function not yet implemented as console-accessible call
     """
     __print_statements()
-    msg = f'The compare function is not yet implemented (map_files={map_files}, f_ecotopes={f_ecotopes}, wd={wd})'
-    raise NotImplementedError(msg)
+    print(
+        f'The compare function is not yet implemented.\n'
+    )
+    sys.exit(1)
 
 
 @app_emma.command(name='license', help='print license of EMMA')
 def license() -> None:
-    """Print the full license of EMMA to the screen."""
+    """Print the full license of EMMA to the screen (Apache-2.0)."""
     with open(os.path.join(os.path.dirname(__file__)[:-3], 'LICENSE'), mode='r') as f:
         print(''.join(f.readlines()))
 
 
 if __name__ == '__main__':
+    # Execute the EMMA-application.
     app_emma()

--- a/src/console.py
+++ b/src/console.py
@@ -3,6 +3,7 @@ Run EMMA from the command-line.
 
 Author: Gijs G. Hendrickx
 """
+import os
 import typing
 
 import typer
@@ -35,6 +36,16 @@ def __log_levels(log: str) -> str:
     return log
 
 
+def __print_statements() -> None:
+    """Print copyright-statements."""
+    print(
+        'EMMA  Copyright (c)  EMMA development team\n'
+        'This program comes with NO WARRANTY.\n'
+        'This is free software, and you are welcome to use and redistribute it\n'
+        'under the conditions as specified in the license; see LICENSE\n'
+    )
+
+
 @app_emma.command(name='run', help='execution of EMMA with customisation of the basic optional arguments')
 def run(
         map_files: te.Annotated[typing.List[str], typer.Argument(help='hydrodynamic output map-file(s)')],
@@ -64,6 +75,7 @@ def run(
     :type n_cores: int, optional
     :type wd: str, optional
     """
+    __print_statements()
     # noinspection PyArgumentList
     processing.map_ecotopes(
         *map_files,
@@ -79,7 +91,7 @@ def run(
     )
 
 
-@app_emma.command(name='compare', help='compare EMMA predictions to existing ecotope-maps')
+@app_emma.command(name='compare', help='[NOT YET IMPLEMENTED] compare EMMA predictions to existing ecotope-maps')
 def compare(
         map_files: te.Annotated[typing.List[str], typer.Argument(help='hydrodynamic output map-file(s)')],
         f_ecotopes: te.Annotated[str, typer.Argument(help='file with ecotope polygon data')],
@@ -97,8 +109,16 @@ def compare(
 
     :raise NotImplementedError: function not yet implemented as console-accessible call
     """
+    __print_statements()
     msg = f'The compare function is not yet implemented (map_files={map_files}, f_ecotopes={f_ecotopes}, wd={wd})'
     raise NotImplementedError(msg)
+
+
+@app_emma.command(name='license', help='print license of EMMA')
+def license() -> None:
+    """Print the full license of EMMA to the screen."""
+    with open(os.path.join(os.path.dirname(__file__)[:-3], 'LICENSE'), mode='r') as f:
+        print(''.join(f.readlines()))
 
 
 if __name__ == '__main__':

--- a/src/console.py
+++ b/src/console.py
@@ -120,7 +120,7 @@ def compare(
 def license() -> None:
     """Print the full license of EMMA to the screen (Apache-2.0)."""
     with open(os.path.join(os.path.dirname(__file__)[:-3], 'LICENSE'), mode='r') as f:
-        print(''.join(f.readlines()))
+        print(f.read())
 
 
 if __name__ == '__main__':

--- a/src/console.py
+++ b/src/console.py
@@ -116,13 +116,6 @@ def compare(
     sys.exit(1)
 
 
-@app_emma.command(name='license', help='print license of EMMA')
-def license() -> None:
-    """Print the full license of EMMA to the screen (Apache-2.0)."""
-    with open(os.path.join(os.path.dirname(__file__)[:-3], 'LICENSE'), mode='r') as f:
-        print(f.read())
-
-
 if __name__ == '__main__':
     # Execute the EMMA-application.
     app_emma()

--- a/src/console.py
+++ b/src/console.py
@@ -10,7 +10,7 @@ import typing_extensions as te
 
 from src import processing
 
-APP = typer.Typer()
+app_emma = typer.Typer()
 
 
 def __log_levels(log: str) -> str:
@@ -35,7 +35,7 @@ def __log_levels(log: str) -> str:
     return log
 
 
-@APP.command(name='run', help='execution of EMMA with customisation of the basic optional arguments')
+@app_emma.command(name='run', help='execution of EMMA with customisation of the basic optional arguments')
 def run(
         map_files: te.Annotated[typing.List[str], typer.Argument(help='hydrodynamic output map-file(s)')],
         export: te.Annotated[bool, typer.Option(help='export model data to [wd]')] = True,
@@ -79,7 +79,7 @@ def run(
     )
 
 
-@APP.command(name='compare', help='compare EMMA predictions to existing ecotope-maps')
+@app_emma.command(name='compare', help='compare EMMA predictions to existing ecotope-maps')
 def compare(
         map_files: te.Annotated[typing.List[str], typer.Argument(help='hydrodynamic output map-file(s)')],
         f_ecotopes: te.Annotated[str, typer.Argument(help='file with ecotope polygon data')],
@@ -102,4 +102,4 @@ def compare(
 
 
 if __name__ == '__main__':
-    APP()
+    app_emma()

--- a/src/console.py
+++ b/src/console.py
@@ -3,7 +3,6 @@ Run EMMA from the command-line.
 
 Author: Gijs G. Hendrickx
 """
-import os
 import sys
 import typing
 

--- a/src/console.py
+++ b/src/console.py
@@ -1,0 +1,65 @@
+"""
+Run EMMA from the command-line.
+
+Author: Gijs G. Hendrickx
+"""
+import typing
+
+import typer
+import typing_extensions as te
+
+from src import processing
+
+APP = typer.Typer()
+
+
+def __log_levels(log: str) -> str:
+    # capitalise all strings
+    log = log.upper()
+    levels = 'DEBUG', 'INFO', 'WARNING', 'CRITICAL'
+
+    # verify validity of `log`-argument
+    if log not in levels:
+        msg = f'Unknown log-level, {log}; choose one of {levels}'
+        raise typer.BadParameter(msg)
+
+    # return log-level
+    return log
+
+
+@APP.command(name='run', help='execution of EMMA with customisation of the basic optional arguments')
+def run(
+        map_files: te.Annotated[typing.List[str], typer.Argument(help='hydrodynamic output map-file(s)')],
+        export: te.Annotated[bool, typer.Option(help='export model data to [wd]')] = True,
+        f_eco_config: te.Annotated[str, typer.Option(help='ecotope configuration file')] = 'emma.json',
+        f_map_config: te.Annotated[str, typer.Option(help='map configuration file')] = 'dfm1.json',
+        log: te.Annotated[str, typer.Option(callback=__log_levels, help='level of log statements')] = 'WARNING',
+        n_cores: te.Annotated[int, typer.Option(min=1, help='number of cores for parallel computations')] = 1,
+        wd: te.Annotated[str, typer.Option(help='working directory')] = None,
+) -> None:
+    # noinspection PyArgumentList
+    processing.map_ecotopes(
+        *map_files,
+        f_export=export,
+        f_eco_config=f_eco_config,
+        f_map_config=f_map_config,
+        export_log=export,
+        log_level=log,
+        n_cores=n_cores,
+        wd=wd,
+        wd_config=wd,
+        wd_export=wd,
+    )
+
+
+@APP.command(name='compare', help='compare EMMA predictions to existing ecotope-maps')
+def compare(
+        map_files: te.Annotated[typing.List[str], typer.Argument(help='hydrodynamic output map-file(s)')],
+        f_ecotopes: te.Annotated[str, typer.Argument(help='file with ecotope polygon data')],
+) -> None:
+    msg = f'The compare function is not yet implemented (map_files={map_files}, f_ecotopes={f_ecotopes})'
+    raise NotImplementedError(msg)
+
+
+if __name__ == '__main__':
+    APP()

--- a/src/processing.py
+++ b/src/processing.py
@@ -12,11 +12,12 @@ import typing
 import numpy as np
 
 from config import config_file
-from src import \
-    _globals as glob, \
-    export as exp, \
-    labelling as lab, \
+from src import (
+    _globals as glob,
+    export as exp,
+    labelling as lab,
     preprocessing as pre
+)
 
 _LOG = logging.getLogger(__name__)
 


### PR DESCRIPTION
Add the option to execute `EMMA` from the command line, directly or via a `Python`-call:
```commandline
emma run MAP_FILES
```
or
```commandline
python src/console.py run MAP_FILES
```